### PR TITLE
WordPress Applience auto updater function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,11 @@ and on top of that:
    
    - Installed from upstream source code to /var/www/wordpress
    - Integrated upgrade mechanism: get WordPress updates straight from
-     WordPress's creator Automattic.
+     WordPress' creator Automattic.
    - Uploading of media such as images, videos, etc.
    - Permalinks configuration supported through admin console
      (convenience)
-   - Automatic plugin upgrades are supported (convenience).
+   - Automatic updates are supported (convenience).
 
 - Useful and popular Wordpress plugins:
    
@@ -31,7 +31,7 @@ and on top of that:
      traffic, mobile, content, and performance tools.
    - `WP Super Cache`_: Accelerates your blog by serving 99% of your
      visitors via static HTML files.
-   - `Ultimate Social Media Icons:`_ Promote your content by adding links to social sharing
+   - `Ultimate Social Media Icons`_: Promote your content by adding links to social sharing
      and bookmarking sites.
    - `Simple Tags`_: automatically adds tags and related posts to your
      content.
@@ -70,17 +70,17 @@ Credentials *(passwords set at first boot)*
 .. _TurnKey Core: http://www.turnkeylinux.org/core
 .. _Wordpress-SEO: http://yoast.com/wordpress/seo/
 .. _NextGEN Gallery: http://wordpress.org/extend/plugins/nextgen-gallery/
-.. _WordPress.com Stats: http://wordpress.org/extend/plugins/stats/
+.. _JetPack for WordPress: http://wordpress.org/extend/plugins/jetpack/
 .. _WP Super Cache: http://wordpress.org/extend/plugins/wp-super-cache/
-.. _`Sociable:`: http://wordpress.org/extend/plugins/sociable/
-.. _Viper's Video Quicktags: http://wordpress.org/extend/plugins/vipers-video-quicktags/
+.. _Ultimate Social Media Icons: http://wordpress.org/extend/plugins/ultimate-social-media-icons/
 .. _Simple Tags: http://wordpress.org/extend/plugins/simple-tags/
-.. _WP-DB-Backup: http://wordpress.org/extend/plugins/wp-db-backup/
+.. _BackupWordPress: http://wordpress.org/extend/plugins/backupwordpress/
 .. _Google Analytics for WordPress: http://yoast.com/wordpress/google-analytics/
 .. _WP-Polls: http://wordpress.org/extend/plugins/wp-polls/
-.. _podPress: http://wordpress.org/extend/plugins/podpress/
+.. _WP-Update-Notifier: http://wordpress.org/extend/plugins/wp-updates-notifier/
 .. _WP-PageNavi: http://wordpress.org/extend/plugins/wp-pagenavi/
 .. _Ozh admin dropdown menu: http://wordpress.org/extend/plugins/ozh-admin-drop-down-menu/
 .. _Contact From 7: http://wordpress.org/extend/plugins/contact-form-7/
+.. _Seriously Simple Podcasting: http://wordpress.org/extend/plugins/seriously-simple-podcasting/
 .. _PHPMyAdmin: http://www.phpmyadmin.net/
 .. _WordPress docs: http://www.turnkeylinux.org/docs/wordpress

--- a/README.rst
+++ b/README.rst
@@ -26,15 +26,16 @@ and on top of that:
      and XML sitemaps.
    - `NextGEN Gallery`_: Easy to use image gallery with a Flash
      slideshow option.
-   - `WordPress.com Stats`_: Provides detailed visitor statistics,
-     optimized for blogging.
+   - `JetPack for WordPress`_: Jetpack adds powerful features previously
+     only available to WordPress.com users including customization,
+     traffic, mobile, content, and performance tools.
    - `WP Super Cache`_: Accelerates your blog by serving 99% of your
      visitors via static HTML files.
    - `Ultimate Social Media Icons:`_ Promote your content by adding links to social sharing
      and bookmarking sites.
    - `Simple Tags`_: automatically adds tags and related posts to your
      content.
-   - `WP-DB-Backup`_: easily backup your core WordPress tables.
+   - `BackupWordPress`_: easily backup your core WordPress tables.
    - `Google Analytics for WordPress`_: track visitors, AdSense clicks,
      outgoing links, and search queries.
    - `WP-Polls`_: Adds an easily customizable AJAX poll system to your
@@ -46,6 +47,7 @@ and on top of that:
      CAPTCHA and Akismet integration.
    - `WP-Update-Notifier`_: Sends email to notify you if there are any updates for your
      WordPress site. Can notify about core, plugin and theme updates.
+   - `Seriously Simple Podcasting`_: Simple Podcasting from your WordPress site.
 
 - SSL support out of the box.
 - `PHPMyAdmin`_ administration frontend for MySQL (listening on port

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ and on top of that:
      links.
    - `Contact From 7`_: Customizable contact forms supporting AJAX,
      CAPTCHA and Akismet integration.
+   - `WP-Update-Notifier`_: Sends email to notify you if there are any updates for your
+     WordPress site. Can notify about core, plugin and theme updates.
 
 - SSL support out of the box.
 - `PHPMyAdmin`_ administration frontend for MySQL (listening on port

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ WordPress - Blog Publishing Platform
 `WordPress`_ is a state-of-the-art publishing platform with a focus on
 aesthetics, web standards, and usability. It is one of the worlds most
 popular blog publishing applications, includes tons of powerful core
-functionality, extendable via literally hundreds of plugins, and
+functionality, extendable via literally thousands of plugins, and
 supports full theming.
 
 This appliance includes all the standard features in `TurnKey Core`_,
@@ -30,19 +30,15 @@ and on top of that:
      optimized for blogging.
    - `WP Super Cache`_: Accelerates your blog by serving 99% of your
      visitors via static HTML files.
-   - `Sociable:`_ Promote your content by adding links to social sharing
+   - `Ultimate Social Media Icons:`_ Promote your content by adding links to social sharing
      and bookmarking sites.
-   - `Viper's Video Quicktags`_: easily embed videos from all the major
-     web video sites.
    - `Simple Tags`_: automatically adds tags and related posts to your
      content.
-   - `WP-DB-Backup`_: easily backup your core WordPress tables.  -
-     `Google Analytics for WordPress`_: track visitors, AdSense clicks,
+   - `WP-DB-Backup`_: easily backup your core WordPress tables.
+   - `Google Analytics for WordPress`_: track visitors, AdSense clicks,
      outgoing links, and search queries.
    - `WP-Polls`_: Adds an easily customizable AJAX poll system to your
      blog.
-   - `podPress`_: Adds features to make WordPress the ideal platform for
-     hosting a podcast.
    - `WP-PageNavi`_: Adds more advanced paging navigation.
    - `Ozh admin dropdown menu`_: Creates a drop down menu with all admin
      links.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,35 @@
+turnkey-wordpress-13.1 (1) turnkey; urgency=low
+
+  * WordPress:
+
+    - Latest upstream version of WordPress and plugins (except for those
+      specified below).
+    - Increase PHP memory limit [#19].
+
+  * Upstream source component versions:
+
+    wp-super-cache              1.2
+    wp-pagenavi                 2.83
+
+  * Added plugins
+  
+    jetpack           (new solution for wp.com services, replaces stats)
+    backupwordpress   (replaces wp-db-backup)
+
+  * Removed plugins
+
+    podpress          (removed from WordPress plugin repo)
+    socialable        (no active maintanance)
+    stats             (is now merged into jetpack)
+    wp-db-backup      (not compatible with WordPress 4)
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jeroen Peters <jeroenpeters1986@gmail.com>  Fri, 26 Feb 2015 11:35:02 +0300
+ -- Built on version 13.0 of Alon Swartz <alon@turnkeylinux.org>
+
+
 turnkey-wordpress-13.0 (1) turnkey; urgency=low
 
   * WordPress:
@@ -19,7 +51,6 @@ turnkey-wordpress-13.0 (1) turnkey; urgency=low
     simple-tags         2.2
     sociable            4.3.3
     contact-form        7.3.3.3
-    podpress            8.8.10.13
 
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.

--- a/changelog
+++ b/changelog
@@ -1,20 +1,20 @@
 turnkey-wordpress-13.1 (1) turnkey; urgency=low
 
+  * Apache2
+
+    - Replaced apache2 package with apache2-mpm-itk
+
   * WordPress:
 
-    - Latest upstream version of WordPress and plugins (except for those
-      specified below).
-    - Increase PHP memory limit [#19].
-
-  * Upstream source component versions:
-
-    wp-super-cache              1.2
-    wp-pagenavi                 2.83
+    - Latest upstream version of WordPress and plugins
+    - Increased PHP upload and max_posts size limits
+    - Made sure all the plugins are downloaded as the latest (stable)upstream version
 
   * Added plugins
   
-    jetpack           (new solution for wp.com services, replaces stats)
-    backupwordpress   (replaces wp-db-backup)
+    jetpack                      (new solution for wp.com services, replaces stats)
+    backupwordpress              (replaces wp-db-backup)
+    seriously-simple-podcasting  (replaces podpress)
 
   * Removed plugins
 

--- a/changelog
+++ b/changelog
@@ -1,14 +1,11 @@
 turnkey-wordpress-13.1 (1) turnkey; urgency=low
 
-  * Apache2
-
-    - Replaced apache2 package with apache2-mpm-itk
-
   * WordPress:
 
     - Latest upstream version of WordPress and plugins
     - Increased PHP upload and max_posts size limits
     - Made sure all the plugins are downloaded as the latest (stable)upstream version
+    - WordPress can now updat itself and install plugins without asking for FTP credentials
 
   * Added plugins
   

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -16,16 +16,14 @@ mkdir -p $PLUGINS_SRC
 URL="http://downloads.wordpress.org/plugin"
 dl $URL/wordpress-seo.latest-stable.zip $PLUGINS_SRC
 dl $URL/nextgen-gallery.zip $PLUGINS_SRC
-dl $URL/stats.zip $PLUGINS_SRC
-dl $URL/vipers-video-quicktags.zip $PLUGINS_SRC
+dl $URL/jetpack.latest-stable.zip $PLUGINS_SRC
 dl $URL/google-analytics-for-wordpress.latest-stable.zip $PLUGINS_SRC
 dl $URL/wp-polls.zip $PLUGINS_SRC
 dl $URL/ozh-admin-drop-down-menu.zip $PLUGINS_SRC
 dl $URL/wp-super-cache.zip $PLUGINS_SRC
-dl $URL/sociable.zip $PLUGINS_SRC
+dl $URL/ultimate-social-media-icons.latest-stable.zip $PLUGINS_SRC
 dl $URL/simple-tags.zip $PLUGINS_SRC
-dl $URL/wp-db-backup.zip $PLUGINS_SRC
-#dl $URL/podpress.zip $PLUGINS_SRC
+dl $URL/backupwordpress.latest-stable.zip $PLUGINS_SRC
 dl $URL/wp-pagenavi.zip $PLUGINS_SRC
-dl $URL/contact-form.3.7.2.zip $PLUGINS_SRC
+dl $URL/contact-form-7.latest-stable.zip $PLUGINS_SRC
 

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -25,7 +25,7 @@ dl $URL/wp-super-cache.zip $PLUGINS_SRC
 dl $URL/sociable.zip $PLUGINS_SRC
 dl $URL/simple-tags.zip $PLUGINS_SRC
 dl $URL/wp-db-backup.zip $PLUGINS_SRC
-dl $URL/podpress.zip $PLUGINS_SRC
+#dl $URL/podpress.zip $PLUGINS_SRC
 dl $URL/wp-pagenavi.zip $PLUGINS_SRC
 dl $URL/contact-form.3.7.2.zip $PLUGINS_SRC
 

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -15,15 +15,16 @@ dl http://wordpress.org/latest.tar.gz $SRC
 mkdir -p $PLUGINS_SRC
 URL="http://downloads.wordpress.org/plugin"
 dl $URL/wordpress-seo.latest-stable.zip $PLUGINS_SRC
-dl $URL/nextgen-gallery.zip $PLUGINS_SRC
+dl $URL/nextgen-gallery.latest-stable.zip $PLUGINS_SRC
 dl $URL/jetpack.latest-stable.zip $PLUGINS_SRC
 dl $URL/google-analytics-for-wordpress.latest-stable.zip $PLUGINS_SRC
-dl $URL/wp-polls.zip $PLUGINS_SRC
-dl $URL/ozh-admin-drop-down-menu.zip $PLUGINS_SRC
-dl $URL/wp-super-cache.zip $PLUGINS_SRC
+dl $URL/wp-polls.latest-stable.zip $PLUGINS_SRC
+dl $URL/ozh-admin-drop-down-menu.latest-stable.zip $PLUGINS_SRC
+dl $URL/wp-super-cache.latest-stable.zip $PLUGINS_SRC
 dl $URL/ultimate-social-media-icons.latest-stable.zip $PLUGINS_SRC
-dl $URL/simple-tags.zip $PLUGINS_SRC
+dl $URL/simple-tags.latest-stable.zip $PLUGINS_SRC
 dl $URL/backupwordpress.latest-stable.zip $PLUGINS_SRC
-dl $URL/wp-pagenavi.zip $PLUGINS_SRC
+dl $URL/seriously-simple-podcasting.latest-stable.zip $PLUGINS_SRC
+dl $URL/wp-pagenavi.latest-stable.zip $PLUGINS_SRC
 dl $URL/contact-form-7.latest-stable.zip $PLUGINS_SRC
 

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -28,3 +28,4 @@ dl $URL/seriously-simple-podcasting.latest-stable.zip $PLUGINS_SRC
 dl $URL/wp-pagenavi.latest-stable.zip $PLUGINS_SRC
 dl $URL/contact-form-7.latest-stable.zip $PLUGINS_SRC
 
+dl https://github.com/l3rady/wp-updates-notifier/archive/master.zip $PLUGINS_SRC

--- a/conf.d/main
+++ b/conf.d/main
@@ -10,9 +10,13 @@ ADMIN_USER=admin
 ADMIN_PASS=turnkey
 ADMIN_MAIL=admin@example.com
 
-# increase php memory limit
+# increase php running limits
 PHPINI=/etc/php5/apache2/php.ini
-sed -i "s|^memory_limit.*|memory_limit = 64M|" $PHPINI
+sed -i "s|^memory_limit.*|memory_limit = 128M|" $PHPINI
+sed -i "s|^upload_max_filesize.*|upload_max_filesize = 16M|" $PHPINI
+sed -i "s|^post_max_size.*|post_max_size = 48M|" $PHPINI
+sed -i "s|^allow_url_fopen.*|allow_url_fopen = On|" $PHPINI
+
 
 # unpack wordpress
 tar -zxf /usr/local/src/latest.tar.gz -C $(dirname $WPROOT)

--- a/conf.d/main
+++ b/conf.d/main
@@ -40,7 +40,6 @@ define('LOGGED_IN_KEY', '$(mcookie)$(mcookie)');
 define('LOGGED_IN_SALT', '$(mcookie)$(mcookie)');
 define('NONCE_KEY', '$(mcookie)$(mcookie)');
 define('NONCE_SALT', '$(mcookie)$(mcookie)');
-define('FS_METHOD', 'direct');
 
 \$table_prefix  = '$DB_PREFIX';
 
@@ -49,6 +48,9 @@ define ('WPLANG', '');
 
 // WordPress debugging mode (for developers).
 define('WP_DEBUG', false);
+
+// WordPress update method
+define('FS_METHOD', 'direct');
 
 // Single-Site (serves any hostname)
 // For Multi-Site, see: http://www.turnkeylinux.org/docs/wordpress/multisite
@@ -109,10 +111,8 @@ rm $WPROOT/wp-admin/turnkey-install.php
 # edit first post to include useful information
 mysql --defaults-extra-file=/etc/mysql/debian.cnf <<EOF
 USE $NAME;
-UPDATE ${DB_PREFIX}posts SET post_title = 'Welcome to WordPress!'
-WHERE ID = '1';
-UPDATE ${DB_PREFIX}posts SET post_content = 'Getting started...<ul><li><a href="/wp-login.php">Login</a> as <b>admin</b> and get blogging!</li><li>Refer to the <a href="http://www.turnkeylinux.org/wordpress">TurnKey WordPress release notes</a></li><li>Refer to the <a href="http://codex.wordpress.org/Getting_Started_with_WordPress">Wordpress Getting Started Codex</a></li></ul>'
-WHERE ID = '1';
+UPDATE ${DB_PREFIX}posts SET post_title = 'Welcome to WordPress!' WHERE ID = '1';
+UPDATE ${DB_PREFIX}posts SET post_content = 'Getting started...<ul><li><a href="/wp-login.php">Login</a> as <b>admin</b> and get blogging!</li><li>Refer to the <a href="http://www.turnkeylinux.org/wordpress">TurnKey WordPress release notes</a></li><li>Refer to the <a href="http://codex.wordpress.org/Getting_Started_with_WordPress">Wordpress Getting Started Codex</a></li></ul>' WHERE ID = '1';
 EOF
 
 # unpack and configure plugins

--- a/conf.d/main
+++ b/conf.d/main
@@ -17,7 +17,6 @@ sed -i "s|^upload_max_filesize.*|upload_max_filesize = 16M|" $PHPINI
 sed -i "s|^post_max_size.*|post_max_size = 48M|" $PHPINI
 sed -i "s|^allow_url_fopen.*|allow_url_fopen = On|" $PHPINI
 
-
 # unpack wordpress
 tar -zxf /usr/local/src/latest.tar.gz -C $(dirname $WPROOT)
 rm /usr/local/src/latest.tar.gz
@@ -121,8 +120,6 @@ PLUGINS_DST="/var/www/wordpress/wp-content/plugins"
 for plugin in $(ls $PLUGINS_SRC/*.zip); do unzip -o $plugin -d $PLUGINS_DST; done
 chown -R www-data:www-data /var/www/wordpress/wp-content
 rm -rf $PLUGINS_SRC
-
-#
 
 # stop mysql server
 /etc/init.d/mysql stop

--- a/overlay/usr/lib/inithooks/bin/wordpress.py
+++ b/overlay/usr/lib/inithooks/bin/wordpress.py
@@ -14,6 +14,7 @@ import hashlib
 from dialog_wrapper import Dialog
 from mysqlconf import MySQL
 
+
 def usage(s=None):
     if s:
         print >> sys.stderr, "Error:", s

--- a/plan/main
+++ b/plan/main
@@ -11,4 +11,6 @@ php-gettext         /* wordpress dep */
 php5-gd             /* wordpress dep */
 tinymce             /* wordpress dep */
 
+php5-curl           /* needed by some plugins */
+
 unzip               /* most wordpress plugins and themes are zip archives */


### PR DESCRIPTION
In these changes I've:
 - removed a few plugins which were not maintained or availabe anymore
 - added plugins which fill the gap of the removed plugins
 - tweaked a few php.ini settings (bigger upload/post values)
 - added the FS_DIRECT update method in wp-config.php
 - added php5-curl install (required for some plugins like jetpack)

Please:
 - verify this setup is safe
 - check the versioning of the changelog, I could not find any guidelines
 - leave me feedback if there is something that needs improvement, this is my first run at TKLdev

What I've tested after the installation:
 - upload media
  - cropping pictures
 - upload an old plugin by uploading a .zip
  - updating this plugin by the autoupdater
 - install a plugin from wordpress repository
 - install a theme from wordpress repository
 - used the default WordPress export & import script to verify media and upload handling