### PR TITLE
Disabled directory listing

### DIFF
--- a/overlay/etc/apache2/sites-available/wordpress.conf
+++ b/overlay/etc/apache2/sites-available/wordpress.conf
@@ -15,6 +15,7 @@ ServerName localhost
 
 <Directory /var/www/wordpress>
     Options +FollowSymLinks
+    Options -Indexes
     AllowOverride All
     order allow,deny
     allow from all


### PR DESCRIPTION
Disabled apache2 directory listing so the WordPress upload folders aren't browsable by default