### PR TITLE
Enter user name at install (turnkeylinux/tracker#444)

### DIFF
--- a/changelog
+++ b/changelog
@@ -20,6 +20,11 @@ turnkey-wordpress-14.0 (1) turnkey; urgency=low
     stats             (is now merged into jetpack)
     wp-db-backup      (not compatible with WordPress 4)
 
+  * Installation
+    
+    The installation wizard now asks for an admin-username. This way, users will have the 
+    option to avoid a default user named 'admin', making bruteforce attacks a little harder.
+
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.
     

--- a/overlay/usr/lib/inithooks/bin/wordpress.py
+++ b/overlay/usr/lib/inithooks/bin/wordpress.py
@@ -22,6 +22,7 @@ def usage(s=None):
     print >> sys.stderr, __doc__
     sys.exit(1)
 
+
 def main():
     try:
         opts, args = getopt.gnu_getopt(sys.argv[1:], "h",
@@ -31,6 +32,7 @@ def main():
 
     password = ""
     email = ""
+    adminuser = ""
     for opt, val in opts:
         if opt in ('-h', '--help'):
             usage()
@@ -39,19 +41,29 @@ def main():
         elif opt == '--email':
             email = val
 
+    if not adminuser:
+        if 'd' not in locals():
+            d = Dialog('TurnKey Linux - First boot configuration')
+
+        adminuser = d.get_username(
+            "Wordpress Admin Username",
+            "Please enter a username for your WordPress admin-account. "
+            "This is used to access the WordPress Admin Dashboard.",
+            "admin")
+
     if not password:
         d = Dialog('TurnKey Linux - First boot configuration')
         password = d.get_password(
-            "Wordpress Password",
-            "Enter new password for the Wordpress 'admin' account.")
+            "WordPress Password",
+            "Enter new password for your WordPress '{0}' account.".format(adminuser))
 
     if not email:
         if 'd' not in locals():
             d = Dialog('TurnKey Linux - First boot configuration')
 
         email = d.get_email(
-            "Wordpress Email",
-            "Please enter email address for the Wordpress 'admin' account.",
+            "WordPress Email",
+            "Please enter email address for your WordPress '{0}' account.".format(adminuser),
             "admin@example.com")
     
     hashpass = hashlib.md5(password).hexdigest()
@@ -59,6 +71,10 @@ def main():
     m = MySQL()
     m.execute('UPDATE wordpress.wp_users SET user_email=\"%s\" WHERE user_nicename=\"admin\";' % email)
     m.execute('UPDATE wordpress.wp_users SET user_pass=\"%s\" WHERE user_nicename=\"admin\";' % hashpass)
+
+    if adminuser != 'admin':
+        m.execute('UPDATE wordpress.wp_users SET user_login=\"%s\" WHERE user_nicename=\"admin\";'
+                  % adminuser)
 
 if __name__ == "__main__":
     main()

--- a/overlay/usr/lib/inithooks/bin/wordpress.py
+++ b/overlay/usr/lib/inithooks/bin/wordpress.py
@@ -45,7 +45,7 @@ def main():
         if 'd' not in locals():
             d = Dialog('TurnKey Linux - First boot configuration')
 
-        adminuser = d.get_username(
+        adminuser = d.get_input(
             "Wordpress Admin Username",
             "Please enter a username for your WordPress admin-account. "
             "This is used to access the WordPress Admin Dashboard.",


### PR DESCRIPTION
Users are now able to enter a desired username in the WordPress install wizard. This resolves turnkeylinux/tracker#444