### PR TITLE
reinstate ultimate-social-media-icons plugin

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,7 +3,6 @@ turnkey-wordpress-14.1 (1) turnkey; urgency=low
   * WordPress:
 
     - Latest upstream version of WordPress and plugins
-    - ultimate-social-media-icons temporarily removed as not currently available
 
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -21,7 +21,7 @@ dl $URL/google-analytics-for-wordpress.latest-stable.zip $PLUGINS_SRC
 dl $URL/wp-polls.latest-stable.zip $PLUGINS_SRC
 dl $URL/ozh-admin-drop-down-menu.latest-stable.zip $PLUGINS_SRC
 dl $URL/wp-super-cache.latest-stable.zip $PLUGINS_SRC
-#dl $URL/ultimate-social-media-icons.latest-stable.zip $PLUGINS_SRC
+dl $URL/ultimate-social-media-icons.latest-stable.zip $PLUGINS_SRC
 dl $URL/simple-tags.latest-stable.zip $PLUGINS_SRC
 dl $URL/backupwordpress.latest-stable.zip $PLUGINS_SRC
 dl $URL/seriously-simple-podcasting.latest-stable.zip $PLUGINS_SRC


### PR DESCRIPTION
ultimate-social-media-icons plugin download is back up so rebuilding WP for v14.1