### PR TITLE
Updated Wordpress to use Service Wrapper

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,16 @@
+turnkey-wordpress-15.0 (1) turnkey; urgency=low
+
+  * Latest version of WordPress
+
+  * Install Adminer directly from stretch/main repo
+
+  * Replace MySQL with MariaDB
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specdific to this appliance.
+
+ -- Stefan Davis <stefan@turnkeylinux.org>  Thu, 09 Nov 2017 22:49:52 +1100
+
 turnkey-wordpress-14.2 (1) turnkey; urgency=low
 
   * Upgraded WordPress to latest upstream version (v4.7.4).

--- a/conf.d/main
+++ b/conf.d/main
@@ -11,7 +11,7 @@ ADMIN_PASS=turnkey
 ADMIN_MAIL=admin@example.com
 
 # increase php running limits
-PHPINI=/etc/php5/apache2/php.ini
+PHPINI=/etc/php/7.0/apache2/php.ini
 sed -i "s|^memory_limit.*|memory_limit = 128M|" $PHPINI
 sed -i "s|^upload_max_filesize.*|upload_max_filesize = 16M|" $PHPINI
 sed -i "s|^post_max_size.*|post_max_size = 48M|" $PHPINI
@@ -88,7 +88,8 @@ EOF
 a2dissite 000-default
 a2ensite wordpress
 a2enmod rewrite
-/etc/init.d/apache2 start
+
+APACHE_STARTED_BY_SYSTEMD="y" /usr/sbin/apachectl start
 
 cat >$WPROOT/wp-admin/turnkey-install.php<<EOF
 <?php
@@ -110,7 +111,7 @@ EOF
 curl http://127.0.0.1/wp-admin/turnkey-install.php >/dev/null
 rm $WPROOT/wp-admin/turnkey-install.php
 
-/etc/init.d/apache2 stop
+/usr/sbin/apachectl stop
 
 # edit first post to include useful information
 mysql --defaults-extra-file=/etc/mysql/debian.cnf <<EOF

--- a/conf.d/main
+++ b/conf.d/main
@@ -89,7 +89,7 @@ a2dissite 000-default
 a2ensite wordpress
 a2enmod rewrite
 
-APACHE_STARTED_BY_SYSTEMD="y" /usr/sbin/apachectl start
+service apache2 start
 
 cat >$WPROOT/wp-admin/turnkey-install.php<<EOF
 <?php
@@ -111,7 +111,7 @@ EOF
 curl http://127.0.0.1/wp-admin/turnkey-install.php >/dev/null
 rm $WPROOT/wp-admin/turnkey-install.php
 
-/usr/sbin/apachectl stop
+service apache2 stop
 
 # edit first post to include useful information
 mysql --defaults-extra-file=/etc/mysql/debian.cnf <<EOF

--- a/plan/main
+++ b/plan/main
@@ -8,9 +8,9 @@ libjs-scriptaculous /* wordpress dep */
 libphp-phpmailer    /* wordpress dep */
 libphp-snoopy       /* wordpress dep */
 php-gettext         /* wordpress dep */
-php5-gd             /* wordpress dep */
+php-gd             /* wordpress dep */
 tinymce             /* wordpress dep */
 
-php5-curl           /* needed by some plugins */
+php-curl           /* needed by some plugins */
 
 unzip               /* most wordpress plugins and themes are zip archives */


### PR DESCRIPTION
Updated Wordpress to use service wrapper (requires https://github.com/turnkeylinux/common/pull/99)