### PR TITLE
16.0 - refactoring and installation of wp-cli

### DIFF
--- a/changelog
+++ b/changelog
@@ -17,6 +17,9 @@ turnkey-wordpress-16.0 (1) turnkey; urgency=low
   * Exclude default cache location (/var/www/wordpress/wp-content/cache) from
     TKLBAM profile. Closes #1411.
 
+  * Note: Please refer to turnkey-core's v16.0 changelog for changes common to
+    all appliances. Here we only describe changes specific to this appliance.
+
  -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 16 Apr 2020 14:16:10 +1000
 
 turnkey-wordpress-15.3 (1) turnkey; urgency=low

--- a/changelog
+++ b/changelog
@@ -1,3 +1,19 @@
+turnkey-wordpress-16.0 (1) turnkey; urgency=low
+
+  * Update Wordpress to latest upstream version - 5.4.
+
+  * Update WordPress inithook to python3.
+    [ Stefan Davis ]
+
+  * Include wp-cli tool. Closes #293.
+
+  * Enable WP_CACHE by default.
+
+  * Exclude default cache location (/var/www/wordpress/wp-content/cache) from
+    TKLBAM profile. Closes #1411.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 03 Apr 2020 17:42:47 +1100
+
 turnkey-wordpress-15.3 (1) turnkey; urgency=low
 
   * Update WordPress to latest upstream version - 5.2.

--- a/changelog
+++ b/changelog
@@ -7,12 +7,17 @@ turnkey-wordpress-16.0 (1) turnkey; urgency=low
 
   * Include wp-cli tool. Closes #293.
 
+  * Include 'turnkey-wp' convenience script (leverages runuser to run as
+    www-data and sets --path=/var/www/wordpress).
+
+  * Leverage wp-cli (via turnkey-wp) to regenerate salts on firstboot.
+
   * Enable WP_CACHE by default.
 
   * Exclude default cache location (/var/www/wordpress/wp-content/cache) from
     TKLBAM profile. Closes #1411.
 
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 03 Apr 2020 17:42:47 +1100
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 16 Apr 2020 14:16:10 +1000
 
 turnkey-wordpress-15.3 (1) turnkey; urgency=low
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -58,6 +58,13 @@ define('FS_METHOD', 'direct');
 define('AUTOMATIC_UPDATER_DISABLED', false);
 define('WP_AUTO_UPDATE_CORE', 'minor');
 
+// Workaround wp-cli issue with unset HTTP_HOST
+// For more info  see https://github.com/wp-cli/wp-cli/issues/2431 &/or
+// https://make.wordpress.org/cli/handbook/common-issues/#php-notice-undefined-index-on-_server-superglobal
+if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( \$_SERVER['HTTP_HOST'] ) ) {
+    \$_SERVER['HTTP_HOST'] = 'localhost';
+}
+
 // Single-Site (serves any hostname)
 // For Multi-Site, see: https://www.turnkeylinux.org/docs/wordpress/multisite
 define('WP_SITEURL', 'http://'.\$_SERVER['HTTP_HOST']);

--- a/conf.d/main
+++ b/conf.d/main
@@ -40,6 +40,7 @@ define('SECURE_AUTH_SALT', '$(mcookie)$(mcookie)');
 define('LOGGED_IN_SALT', '$(mcookie)$(mcookie)');
 define('NONCE_SALT', '$(mcookie)$(mcookie)');
 
+define('WP_CACHE', true);
 define('DISABLE_WP_CRON', true);
 
 \$table_prefix  = '$DB_PREFIX';

--- a/conf.d/main
+++ b/conf.d/main
@@ -132,8 +132,13 @@ UPDATE ${DB_PREFIX}posts SET post_content = 'Getting started...<ul><li><a href="
 </ul></li></ul>' WHERE ID = '1';
 EOF
 
-# fix permissions for updates
+# Install wp-cli commandline tool
+wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O /usr/local/bin/wp
+chmod +x /usr/local/bin/wp
+wget https://raw.githubusercontent.com/wp-cli/wp-cli/v2.4.0/utils/wp-completion.bash -O ~/.bashrc.d/wp-completion
+chmod +x ~/.bashrc.d/wp-completion
 
+# fix permissions for updates
 chown -R www-data:www-data $WPROOT
 find $WPROOT -type d -exec chmod 755 {} \;
 find $WPROOT -type f -exec chmod 644 {} \;

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-wordpress-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-wordpress-secrets
@@ -5,18 +5,18 @@
 
 updateconf() {
     CONF=/var/www/wordpress/wp-config.php
-    sed -i "s/\(.*\)$1\(.*\)');/define('$1', '$2');/;" $CONF
+    sed -i "/^define('$1'/ s|,.*|, '$2');|" $CONF
 }
 
-updateconf 'AUTH_KEY' $(mcookie)$(mcookie)
-updateconf 'AUTH_SALT' $(mcookie)$(mcookie)
-updateconf 'SECURE_AUTH_KEY' $(mcookie)$(mcookie)
-updateconf 'SECURE_AUTH_SALT' $(mcookie)$(mcookie)
-updateconf 'LOGGED_IN_KEY' $(mcookie)$(mcookie)
-updateconf 'LOGGED_IN_SALT' $(mcookie)$(mcookie)
-updateconf 'NONCE_KEY' $(mcookie)$(mcookie)
-updateconf 'NONCE_SALT' $(mcookie)$(mcookie)
+updateconf AUTH_KEY $(mcookie)$(mcookie)
+updateconf AUTH_SALT $(mcookie)$(mcookie)
+updateconf SECURE_AUTH_KEY $(mcookie)$(mcookie)
+updateconf SECURE_AUTH_SALT $(mcookie)$(mcookie)
+updateconf LOGGED_IN_KEY $(mcookie)$(mcookie)
+updateconf LOGGED_IN_SALT $(mcookie)$(mcookie)
+updateconf NONCE_KEY $(mcookie)$(mcookie)
+updateconf NONCE_SALT $(mcookie)$(mcookie)
 
 PASSWORD=$(mcookie)
-updateconf 'DB_PASSWORD' $PASSWORD
+updateconf DB_PASSWORD $PASSWORD
 $INITHOOKS_PATH/bin/mysqlconf.py --user=wordpress --pass="$PASSWORD"

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-wordpress-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-wordpress-secrets
@@ -3,19 +3,15 @@
 
 . /etc/default/inithooks
 
+USER=www-data
+WEBROOT=/var/www/wordpress
+CONF=$WEBROOT/wp-config.php
+
 updateconf() {
-    CONF=/var/www/wordpress/wp-config.php
     sed -i "/^define('$1'/ s|,.*|, '$2');|" $CONF
 }
 
-updateconf AUTH_KEY $(mcookie)$(mcookie)
-updateconf AUTH_SALT $(mcookie)$(mcookie)
-updateconf SECURE_AUTH_KEY $(mcookie)$(mcookie)
-updateconf SECURE_AUTH_SALT $(mcookie)$(mcookie)
-updateconf LOGGED_IN_KEY $(mcookie)$(mcookie)
-updateconf LOGGED_IN_SALT $(mcookie)$(mcookie)
-updateconf NONCE_KEY $(mcookie)$(mcookie)
-updateconf NONCE_SALT $(mcookie)$(mcookie)
+runuser $USER -s /bin/bash -c "wp --path=$WEBROOT config shuffle-salts"
 
 PASSWORD=$(mcookie)
 updateconf DB_PASSWORD $PASSWORD

--- a/overlay/usr/local/bin/turnkey-wp
+++ b/overlay/usr/local/bin/turnkey-wp
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+[[ -z "$DEBUG" ]] || set -x
+
+WP_DIR=${WP_DIR:-/var/www/wordpress}
+WP_USR=${WP_USR:-www-data}
+
+COMMAND="wp --path=$WP_DIR $@"
+
+runuser $WP_USR -s /bin/bash -c "$COMMAND"


### PR DESCRIPTION
Some improvements and refactoring; plus installation of `wp-cli` tool - along with a `turnkey-wp` convenience wrapper (that runs `wp` commands as `www-data` user within `/var/www/wordpress`). Also changelog bump.