### PR TITLE
V17.0 update for WordPress Appliance and its Dependencies

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,19 @@
+turnkey-wordpress-17.0 (1) turnkey; urgency=low
+
+  * Updating wordpress appliance and its dependencies with tkldev to v17.0.
+
+  * Bumping php version to 7.4 debian default in conf.d/main.
+
+  * Bumping wp-cli release version to v2.6.0 .
+
+  * Updating and removing outdated packages  tinymce and php-gettext in
+    plan/main file.
+
+  * Note: Please refer to turnkey-core's 17.0 changelog for changes common to
+    all appliances. Here we only describe changes specific to this appliance.
+
+ -- Mattie Darden <mattie@turnkeylinux.org>  Wed, 12 Oct 2022 12:40:06 -0400
+
 turnkey-wordpress-16.1 (1) turnkey; urgency=low
 
   * Update Wordpress to latest upstream version - 5.6.1.

--- a/conf.d/main
+++ b/conf.d/main
@@ -11,7 +11,7 @@ ADMIN_PASS=turnkey
 ADMIN_MAIL=admin@example.com
 
 # increase php running limits
-PHPINI=/etc/php/7.3/apache2/php.ini
+PHPINI=/etc/php/7.4/apache2/php.ini
 sed -i "s|^memory_limit.*|memory_limit = 128M|" $PHPINI
 sed -i "s|^upload_max_filesize.*|upload_max_filesize = 16M|" $PHPINI
 sed -i "s|^post_max_size.*|post_max_size = 48M|" $PHPINI
@@ -20,7 +20,7 @@ sed -i "s|^allow_url_fopen.*|allow_url_fopen = On|" $PHPINI
 # Install wp-cli commandline tool
 wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O /usr/local/bin/wp
 chmod +x /usr/local/bin/wp
-wget https://raw.githubusercontent.com/wp-cli/wp-cli/v2.4.0/utils/wp-completion.bash -O ~/.bashrc.d/wp-completion
+wget https://raw.githubusercontent.com/wp-cli/wp-cli/v2.6.0/utils/wp-completion.bash -O ~/.bashrc.d/wp-completion
 chmod +x ~/.bashrc.d/wp-completion
 
 # create the database and user

--- a/overlay/usr/lib/inithooks/bin/wordpress.py
+++ b/overlay/usr/lib/inithooks/bin/wordpress.py
@@ -12,7 +12,7 @@ import getopt
 import inithooks_cache
 import hashlib
 
-from dialog_wrapper import Dialog
+from libinithooks.dialog_wrapper import Dialog
 from mysqlconf import MySQL
 
 

--- a/plan/main
+++ b/plan/main
@@ -7,7 +7,7 @@ libjs-prototype     /* wordpress dep */
 libjs-scriptaculous /* wordpress dep */
 libphp-phpmailer    /* wordpress dep */
 libphp-snoopy       /* wordpress dep */
-php-php-gettext         /* wordpress dep */
+php-php-gettext     /* wordpress dep */
 php-gd              /* wordpress dep */
 php-zip             /* wordpress recommends */
 php-imagick         /* wordpress recommends */

--- a/plan/main
+++ b/plan/main
@@ -7,11 +7,11 @@ libjs-prototype     /* wordpress dep */
 libjs-scriptaculous /* wordpress dep */
 libphp-phpmailer    /* wordpress dep */
 libphp-snoopy       /* wordpress dep */
-php-gettext         /* wordpress dep */
+php-php-gettext         /* wordpress dep */
 php-gd              /* wordpress dep */
-tinymce             /* wordpress dep */
 php-zip             /* wordpress recommends */
 php-imagick         /* wordpress recommends */
+w3m                 /* wordpress recommends */
 
 php-curl            /* needed by some plugins */
 


### PR DESCRIPTION
Update code changes include bumping wordpress cli GH release up to current 2.6.0, and updating php version to Debian default v7.4. Readme.rst file has been reviewed to ensure all information and links are still functional and relevant. 
Removed outdated tinymce WSIWYG editor since appliance update now comes with Gutenberg editor features in built in wordpress editor and offers Gutenberg plugin for additional features. All update changes have been tested and documented in appliance changelog.